### PR TITLE
Fix `waitForRefetchQueries` example in mutation docs

### DIFF
--- a/docs/src/pages/docs/mutations.mdx
+++ b/docs/src/pages/docs/mutations.mdx
@@ -177,6 +177,7 @@ const Blog = () => {
 	const {data: posts} = useQuery(POSTS_QUERY);
 	const {data: pages} = useQuery(PAGES_QUERY);
 	const {mutate: createPost} = useMutation(CREATE_POST_MUTATION, {
+		waitForRefetchQueries: true,
 		refetchQueries: [PAGES_QUERY]
 	});
 


### PR DESCRIPTION
I bet it's meant to be there, since you are saying that "you can opt-in" to it, otherwise it's just the same snippet as the previous one. :)

Btw, pretty cool lib and small API :100: 