### PR TITLE
Fix "Node does not exist" error

### DIFF
--- a/src/Draqula.ts
+++ b/src/Draqula.ts
@@ -245,11 +245,14 @@ export default class Draqula {
 
 		// Find all queries that have at least one __typename from mutation response
 		for (const typename of typenames) {
-			const dependantQueries = this.graph
-				.dependantsOf(`type:${typename}`)
-				.map(queryId => queryId.replace('query:', ''));
+			const nodeName = `type:${typename}`
+			if (this.graph.hasNode(nodeName)) {
+				const dependantQueries = this.graph
+					.dependantsOf(nodeName)
+					.map(queryId => queryId.replace('query:', ''));
 
-			refetchQueries.push(...dependantQueries);
+				refetchQueries.push(...dependantQueries);
+			}
 		}
 
 		// Custom queries to refetch, specified by `useMutation()`


### PR DESCRIPTION
This PR adds a check to verify the node exists before executing `graph.dependantsOf()`, otherwise it could throw an error if the node does not exist (and it could be a valid cache miss).