### PR TITLE
Fixes a typo in the error message in useDraqulaClient.ts.

### DIFF
--- a/src/useDraqulaClient.ts
+++ b/src/useDraqulaClient.ts
@@ -7,7 +7,7 @@ export default (): Draqula => {
 
 	if (!context || !context.client) {
 		throw new Error(
-			"Draqula client couldn't be found. Did you forget to pass client to your React components via DragulaProvider?"
+			"Draqula client couldn't be found. Did you forget to pass client to your React components via DraqulaProvider?"
 		);
 	}
 


### PR DESCRIPTION
Hi Vadim!

I noticed that the error message in `useDraqulaClient.ts` had `DragulaProvider` in it instead of `DraqulaProvider`. I went ahead and changed the `g` to a `q` to match the name of the provider. 😃

Thanks for your work on a nice, minimalistic library and have a great day!!